### PR TITLE
Added rust benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ all: check test
 check:
 	# Doing sanity checks...
 	/usr/bin/time -V
+	cargo --version # Rust
 	java -version # Java
 	gcc --version # C
 	dmd --version # D
@@ -21,6 +22,14 @@ check:
 	ruby --version # Ruby
 
 test:
+	# Rust
+	cp tests/rust/Cargo.toml .
+	mkdir src
+	cp tests/rust/src/main.rs src/
+	${MEASURE} cargo run --release
+	rm Cargo.toml Cargo.lock
+	rm -rf src/
+	rm -rf target/
 	# Java
 	cp tests/Main.java .
 	javac Main.java

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust-benchmark"
+version = "0.1.0"
+authors = ["oak"]
+
+[dependencies]
+time = "0.1.13"

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -1,0 +1,37 @@
+extern crate time;
+
+use time::precise_time_ns;
+use std::io::BufWriter;
+use std::io::prelude::*;
+use std::fs::OpenOptions;
+use std::path::Path;
+use std::iter::repeat;
+
+fn main() {
+    const W: i32 = 25600;
+    const H: i32 = 2048;
+    const SIZE: usize = (W * H) as usize;
+    let mut v: Vec<i32> = repeat(0).take(SIZE).collect();
+    let start = precise_time_ns();
+    for i in 0..W {
+        for j in 0..H{
+            v[(i + W * j) as usize] = i * j;
+        } 
+    }
+    let total = precise_time_ns() - start;
+    println!("{}", total / 1000 / 1000);
+    write_to_null(v[(W+1) as usize]);
+}
+
+fn write_to_null(i :i32) {
+    let path = Path::new("/dev/null");
+    let mut options = OpenOptions::new();
+    options.write(true).append(true);
+            
+    let file = match options.open(path) {
+        Ok(file) => file,
+        Err(..)  => panic!("room"),
+    };
+    let mut buffer = BufWriter::new(&file);
+    write!(buffer, "{}", i);
+}


### PR DESCRIPTION
Note that rust benchmark uses not only rust but cargo as well.
An original git is found here: https://github.com/White-Oak/rust-simple-bench , It consists of two solutions: on-stack and in-heap.
Both are run in a considerable time, being slighter faster than Java.
This commit adds an in-heap solution to a benchmark as it is found to be a little bit quicker than another one during a local testing.
Also it looks prettier than another one :)

Code writes an integer from the calculated array to /dev/null, so the code isn't removed by an optimizing compiler when using --release
option.
